### PR TITLE
Update devopsdays cta

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Your goal is to help Rapu enforce these policies so that resources don't get cre
 
 The concept of the tutorial is agnostic of what Terraform provider you choose. For the sake of a demo, I'll choose [Aiven Terraform Provider](https://registry.terraform.io/providers/aiven/aiven/latest). [Aiven](https://aiven.io/) provides highly-available and scalable data infrastructure based on open-source technologies. For this tutorial, you'll create a [free Aiven account](https://go.aiven.io/dewan-chicago) and [an Aiven authentication token](https://docs.aiven.io/docs/platform/howto/create_authentication_token).
 
-Install [OPA](https://www.openpolicyagent.org/docs/latest/#running-opa) and [Terraform](https://developer.hashicorp.com/terraform/downloads).
+Install [OPA](https://www.openpolicyagent.org/docs/latest/#running-opa), [Terraform](https://developer.hashicorp.com/terraform/downloads) and optionally [jq](https://jqlang.github.io/jq/download/).
 
 ## The Story
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Your goal is to help Rapu enforce these policies so that resources don't get cre
 
 ## Prerequisites
 
-The concept of the tutorial is agnostic of what Terraform provider you choose. For the sake of a demo, I'll choose [Aiven Terraform Provider](https://registry.terraform.io/providers/aiven/aiven/latest). [Aiven](https://aiven.io/) provides highly-available and scalable data infrastructure based on open-source technologies. For this tutorial, you'll create a [free Aiven account](https://console.aiven.io/signup) and [an Aiven authentication token](https://docs.aiven.io/docs/platform/howto/create_authentication_token).
+The concept of the tutorial is agnostic of what Terraform provider you choose. For the sake of a demo, I'll choose [Aiven Terraform Provider](https://registry.terraform.io/providers/aiven/aiven/latest). [Aiven](https://aiven.io/) provides highly-available and scalable data infrastructure based on open-source technologies. For this tutorial, you'll create a [free Aiven account](https://go.aiven.io/dewan-chicago) and [an Aiven authentication token](https://docs.aiven.io/docs/platform/howto/create_authentication_token).
 
 Install [OPA](https://www.openpolicyagent.org/docs/latest/#running-opa) and [Terraform](https://developer.hashicorp.com/terraform/downloads).
 

--- a/modules/01_terraform_deployment_without_OPA.md
+++ b/modules/01_terraform_deployment_without_OPA.md
@@ -37,7 +37,7 @@ variable "project_name" {
 
 ```terraform
 resource "aiven_redis" "redis-demo" {
-    project = var.project_name # Find your Aiven project name from top-left of Aiven console
+    project = var.project_name # The project name is passed from the variable declaration
     plan = "hobbyist" # For this exercise, the hobbyist plan will do
     service_name = "redis-demo" # Choose any service name
     cloud_name = "google-northamerica-northeast1" # Choose any cloud region from https://docs.aiven.io/docs/platform/reference/list_of_clouds

--- a/modules/01_terraform_deployment_without_OPA.md
+++ b/modules/01_terraform_deployment_without_OPA.md
@@ -37,7 +37,7 @@ variable "project_name" {
 
 ```terraform
 resource "aiven_redis" "redis-demo" {
-    project = "devrel-dewan" # Find your Aiven project name from top-left of Aiven console
+    project = var.project_name # Find your Aiven project name from top-left of Aiven console
     plan = "hobbyist" # For this exercise, the hobbyist plan will do
     service_name = "redis-demo" # Choose any service name
     cloud_name = "google-northamerica-northeast1" # Choose any cloud region from https://docs.aiven.io/docs/platform/reference/list_of_clouds

--- a/modules/03_write_policy_in_rego.md
+++ b/modules/03_write_policy_in_rego.md
@@ -62,7 +62,7 @@ If you have [jq](https://stedolan.github.io/jq) installed on your machine, you c
 ./opa exec --decision terraform/analysis/allow_prod_deployment --bundle policy/ tfplan.json | jq '.result[0].result'
 ```
 
-The `opa exac` command is taking in the `tfplan.json` as an input and validating this against the policy we defined in the **allow_prod_deployment** section under policy/terraform.rego file. **terraform/analysis** is denoting the package name in that Rego. 
+The `opa exec` command is taking in the `tfplan.json` as an input and validating this against the policy we defined in the **allow_prod_deployment** section under policy/terraform.rego file. **terraform/analysis** is denoting the package name in that Rego. 
 
 Let's make a change in the `services.tf` file and change the `cloud_name` field to `aws-us-east1`. Now if you repeat steps 2, 3, and 4, the output from the `opa exec` command should be `true`.
 


### PR DESCRIPTION
This PR updates Aiven sign up link with DevOpsDays Chicago 2023 CTA and brings in some other small fixes (thanks to @sebastienblanc ).